### PR TITLE
1 add the key info for ts > now log in expire.go

### DIFF
--- a/db/expire.go
+++ b/db/expire.go
@@ -159,7 +159,7 @@ func runExpire(db *DB, batchLimit int) {
 		ts := DecodeInt64(rawKey[expireTimestampOffset : expireTimestampOffset+8])
 		if ts > now {
 			if logEnv := zap.L().Check(zap.DebugLevel, "[Expire] not need to expire key"); logEnv != nil {
-				logEnv.Write(zap.Int64("last timestamp", ts))
+				logEnv.Write( zap.String("raw key", string(rawKey)), zap.Int64("last timestamp", ts))
 			}
 			break
 		}

--- a/docs/command_list.md
+++ b/docs/command_list.md
@@ -93,7 +93,7 @@
 - [ ] rpop
 - [ ] rpoplpush
 - [x] rpush
-- [ ] rpushhx
+- [x] rpushx
 - [ ] blpop
 - [ ] brpop
 - [ ] brpoplpush
@@ -226,7 +226,6 @@ ___NOTICE: commands beyond this table has already been fully supported___
 |lrem      |List||
 |rpop      |List||
 |rpoplpush |List||
-|rpushhx   |List||
 |blpop     |List||
 |brpop     |List||
 |brpoplpush|List||


### PR DESCRIPTION
2 command_list.md flag rpushhx not open, but redis has no the command, it should be rpushx, which has been implemented and test passed